### PR TITLE
Add financial stats section below header

### DIFF
--- a/Mainpage
+++ b/Mainpage
@@ -281,7 +281,44 @@
 
   <main class="py-10">
     <div class="px-4 sm:px-6 lg:px-8">
-      <!-- Your content -->
+      <dl class="mx-auto grid grid-cols-1 gap-px bg-gray-900/5 sm:grid-cols-2 lg:grid-cols-4 dark:bg-white/10">
+        <div
+          class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 bg-white px-4 py-10 sm:px-6 xl:px-8 dark:bg-gray-900"
+        >
+          <dt class="text-sm/6 font-medium text-gray-500 dark:text-gray-400">Revenue</dt>
+          <dd class="text-xs font-medium text-gray-700 dark:text-gray-300">+4.75%</dd>
+          <dd class="w-full flex-none text-3xl/10 font-medium tracking-tight text-gray-900 dark:text-white">
+            $405,091.00
+          </dd>
+        </div>
+        <div
+          class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 bg-white px-4 py-10 sm:px-6 xl:px-8 dark:bg-gray-900"
+        >
+          <dt class="text-sm/6 font-medium text-gray-500 dark:text-gray-400">Overdue invoices</dt>
+          <dd class="text-xs font-medium text-rose-600 dark:text-rose-400">+54.02%</dd>
+          <dd class="w-full flex-none text-3xl/10 font-medium tracking-tight text-gray-900 dark:text-white">
+            $12,787.00
+          </dd>
+        </div>
+        <div
+          class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 bg-white px-4 py-10 sm:px-6 xl:px-8 dark:bg-gray-900"
+        >
+          <dt class="text-sm/6 font-medium text-gray-500 dark:text-gray-400">Outstanding invoices</dt>
+          <dd class="text-xs font-medium text-gray-700 dark:text-gray-300">-1.39%</dd>
+          <dd class="w-full flex-none text-3xl/10 font-medium tracking-tight text-gray-900 dark:text-white">
+            $245,988.00
+          </dd>
+        </div>
+        <div
+          class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 bg-white px-4 py-10 sm:px-6 xl:px-8 dark:bg-gray-900"
+        >
+          <dt class="text-sm/6 font-medium text-gray-500 dark:text-gray-400">Expenses</dt>
+          <dd class="text-xs font-medium text-rose-600 dark:text-rose-400">+10.18%</dd>
+          <dd class="w-full flex-none text-3xl/10 font-medium tracking-tight text-gray-900 dark:text-white">
+            $30,156.00
+          </dd>
+        </div>
+      </dl>
     </div>
   </main>
 </div>

--- a/index.html
+++ b/index.html
@@ -291,7 +291,44 @@
 
   <main class="py-10">
     <div class="px-4 sm:px-6 lg:px-8">
-      <!-- Your content -->
+      <dl class="mx-auto grid grid-cols-1 gap-px bg-gray-900/5 sm:grid-cols-2 lg:grid-cols-4 dark:bg-white/10">
+        <div
+          class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 bg-white px-4 py-10 sm:px-6 xl:px-8 dark:bg-gray-900"
+        >
+          <dt class="text-sm/6 font-medium text-gray-500 dark:text-gray-400">Revenue</dt>
+          <dd class="text-xs font-medium text-gray-700 dark:text-gray-300">+4.75%</dd>
+          <dd class="w-full flex-none text-3xl/10 font-medium tracking-tight text-gray-900 dark:text-white">
+            $405,091.00
+          </dd>
+        </div>
+        <div
+          class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 bg-white px-4 py-10 sm:px-6 xl:px-8 dark:bg-gray-900"
+        >
+          <dt class="text-sm/6 font-medium text-gray-500 dark:text-gray-400">Overdue invoices</dt>
+          <dd class="text-xs font-medium text-rose-600 dark:text-rose-400">+54.02%</dd>
+          <dd class="w-full flex-none text-3xl/10 font-medium tracking-tight text-gray-900 dark:text-white">
+            $12,787.00
+          </dd>
+        </div>
+        <div
+          class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 bg-white px-4 py-10 sm:px-6 xl:px-8 dark:bg-gray-900"
+        >
+          <dt class="text-sm/6 font-medium text-gray-500 dark:text-gray-400">Outstanding invoices</dt>
+          <dd class="text-xs font-medium text-gray-700 dark:text-gray-300">-1.39%</dd>
+          <dd class="w-full flex-none text-3xl/10 font-medium tracking-tight text-gray-900 dark:text-white">
+            $245,988.00
+          </dd>
+        </div>
+        <div
+          class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 bg-white px-4 py-10 sm:px-6 xl:px-8 dark:bg-gray-900"
+        >
+          <dt class="text-sm/6 font-medium text-gray-500 dark:text-gray-400">Expenses</dt>
+          <dd class="text-xs font-medium text-rose-600 dark:text-rose-400">+10.18%</dd>
+          <dd class="w-full flex-none text-3xl/10 font-medium tracking-tight text-gray-900 dark:text-white">
+            $30,156.00
+          </dd>
+        </div>
+      </dl>
     </div>
   </main>
 </div>


### PR DESCRIPTION
## Summary
- add Tailwind-based stats grid for revenue, invoices, and expenses on main page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a53e56c108322a42462e122abdd82